### PR TITLE
Small fixes

### DIFF
--- a/src/Patterns/Scd4Pattern.php
+++ b/src/Patterns/Scd4Pattern.php
@@ -73,6 +73,7 @@ class Scd4Pattern extends AbstractPattern
             'snapshotSpecialColumns' => $this->getSnapshotSpecialColumns(),
             'snapshotAllColumnsExceptPk' => $this->getSnapshotAllColumnsExceptPk(),
             'deletedActualValue' => $this->config->keepDeleteActive() ? 1 : 0,
+            'generateDeletedRecords' => $this->config->hasDeletedFlag() || $this->config->keepDeleteActive(),
             'tableName' => [
                 'input' => self::TABLE_INPUT,
                 'currentSnapshot' => self::TABLE_CURRENT_SNAPSHOT,

--- a/src/Patterns/templates/Scd2Synapse.twig
+++ b/src/Patterns/templates/Scd2Synapse.twig
@@ -3,92 +3,128 @@
 {% set inputRandomColumn = attribute(inputPrimaryKey, 0) %}
 {% set snapshotInputJoinConditionSql = macro.generateJoin(inputPrimaryKey, "snapshot", "input") %}
 {% set snapshotPrimaryKeySelect = macro.generateSnapshotPrimaryKey(snapshotPrimaryKeyParts, snapshotPrimaryKeyName) %}
--- SCD4: This method snapshot full current state of the data to the snapshot table. --
+-- SCD2: This method tracks historical data --
+-- by creating new records for new/modified data in the snapshot table. --
 
 {% apply noIndent %}
-    {%- if config.useDatetime() -%}
+    {% if config.useDatetime() %}
         {% set currentDate = '$CURRENT_TIMESTAMP_TXT' %}
         {% set infiniteDate = '9999-12-31 00:00:00' | quoteValue %}
         -- The start and end dates contain the time ("use_datetime" = true). --
         SET CURRENT_TIMESTAMP = (SELECT CONVERT_TIMEZONE('{{ timezone }}', current_timestamp())::TIMESTAMP_NTZ);
         SET CURRENT_TIMESTAMP_TXT = (SELECT TO_CHAR($CURRENT_TIMESTAMP, 'YYYY-MM-DD HH:Mi:SS'));
-    {% else -%}
+    {% else %}
         {% set currentDate = '$CURRENT_DATE_TXT' %}
         {% set infiniteDate = '9999-12-31' | quoteValue %}
         -- The start and end dates DO NOT contain the time ("use_datetime" = false). --
         SET CURRENT_DATE = (SELECT CONVERT_TIMEZONE('{{ timezone }}', current_timestamp()))::DATE;
         SET CURRENT_DATE_TXT = (SELECT TO_CHAR($CURRENT_DATE, 'YYYY-MM-DD'));
     {% endif %}
+
+    {% if config.keepDeleteActive() %}
+        {% set deletedEndDate = infiniteDate %}
+    {% else %}
+        {% set deletedEndDate = currentDate %}
+    {% endif %}
 {% endapply %}
 
--- Last state: Actual snapshot of the all rows  --
-CREATE TABLE "last_state" AS
-SELECT
--- Monitored parameters. --
-{{ macro.selectFromColumns(inputColumns, "input.", true) }},
--- The snapshot date is set to now. --
-{{ currentDate }} AS {{ columnName.snapshotDate | quoteIdentifier }},
--- Actual flag is set to "1". --
-1 AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
-    -- IsDeleted flag is set to "0". --
-    0 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
-FROM {{ tableName.input | quoteIdentifier }} input;
+-- Changed records: Input table rows, EXCEPT same rows present in the last snapshot. --
+CREATE TABLE "changed_records" AS
+    WITH "diff_records" AS (
+        -- Actual state. --
+        SELECT {{ macro.selectFromColumns(inputColumns, "input.", true) }}
+        FROM {{ tableName.input | quoteIdentifier }} input
 
--- Previous state: Set actual flag to "0" in the previous version of the records. --
-CREATE TABLE "previous_state" AS
-SELECT
--- Monitored parameters. --
-{{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
--- The snapshot date is preserved. --
-{{ columnName.snapshotDate | quoteIdentifier }},
--- Actual flag is set to "0". --
-0  AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
-    -- IsDeleted flag is preserved. --
-    snapshot.{{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
-FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
-WHERE
--- Only the last results are modified. --
-snapshot.{{ columnName.actual | quoteIdentifier }} = 1
--- Exclude records with the current date (and therefore with the same PK). --
--- This can happen if time is not part of the date, eg. "2020-11-04". --
--- Row for this PK is then already included in the "last_state". --
--- TLDR: for each PK, we can have max one row in the new snapshot. --
-AND snapshot.{{ columnName.snapshotDate | quoteIdentifier }} != {{ currentDate }};
+        EXCEPT
+
+        -- The last snapshot. --
+        SELECT {{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }}
+        FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
+        WHERE {{ columnName.actual | quoteIdentifier }} = 1
+    )
+    SELECT
+        -- Monitored parameters. --
+        {{ macro.selectFromColumns(snapshotInputColumns) }},
+        -- The start date is set to now. --
+        {{ currentDate }} AS {{ columnName.startDate | quoteIdentifier }},
+        -- The end date is set to infinity. --
+        {{ infiniteDate }} AS {{ columnName.endDate | quoteIdentifier }},
+        -- Actual flag is set to "1". --
+        1 AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
+        -- IsDeleted flag is set to "0". --
+        0 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
+    FROM "diff_records";
+
+-- Updated records: Set actual flag to "0" in the previous version. --
+CREATE TABLE "updated_records" AS
+    SELECT
+        -- Monitored parameters. --
+        {{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
+        -- The start date is preserved. --
+        snapshot.{{ columnName.startDate | quoteIdentifier }},
+        -- The end date is set to now. --
+        {{ currentDate }} AS {{ columnName.endDate | quoteIdentifier }},
+        -- Actual flag is set to "0", because the new version exists. --
+        0 AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
+        -- IsDeleted flag is set to "0", because the new version exists. --
+        0 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
+    FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
+    -- Join "changed_records" and "snapshot" table on the defined primary key
+    JOIN "changed_records" changed ON
+    {{ macro.generateJoin(inputPrimaryKeyLower, "snapshot", "changed") }}
+
+    WHERE
+        -- Only previous actual results are modified. --
+        snapshot.{{ columnName.actual | quoteIdentifier }} = 1
+        -- Exclude records with the current date (and therefore with the same PK). --
+        -- This can happen if time is not part of the date, eg. "2020-11-04". --
+        -- Row for this PK is then already included in the "last_state". --
+        -- TLDR: for each PK, we can have max one row in the new snapshot. --
+        AND snapshot.{{ columnName.startDate | quoteIdentifier }} != {{ currentDate }};
 
 -- Deleted records are missing in input table, but have actual "1" in last snapshot. --
 CREATE TABLE "deleted_records" AS
-SELECT
-{{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
--- The snapshot date is set to now. --
-{{ currentDate }} AS {{ columnName.snapshotDate | quoteIdentifier }},
--- The actual flag is set to "{{  deletedActualValue  }}" ("keep_del_active" = {{ config.keepDeleteActive() ? 'true' : 'false' }}). --
-{{ deletedActualValue }} AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
-    -- IsDeleted flag is set to "1". --
-    1 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
-FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
-LEFT JOIN {{ tableName.input | quoteIdentifier }} input ON {{ snapshotInputJoinConditionSql }}
-WHERE
-snapshot.{{ columnName.actual | quoteIdentifier }} = 1 AND
-input.{{ inputRandomColumn | quoteIdentifier }} IS NULL;
+    SELECT
+        -- Values of the monitored parameters. --
+        {{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
+        -- The start date is unchanged, it is part of the PK, --
+        -- so old values are overwritten by incremental loading. --
+        snapshot.{{ columnName.startDate | quoteIdentifier }},
+        -- The end date is set to "{{  deletedEndDate  }}" ("keep_del_active" = {{ config.keepDeleteActive() ? 'true' : 'false' }}). --
+        {{ deletedEndDate }} AS {{ columnName.endDate | quoteIdentifier }},
+        -- The actual flag is set to "{{  deletedActualValue  }}" ("keep_del_active" = {{ config.keepDeleteActive() ? 'true' : 'false' }}). --
+        {{ deletedActualValue }} AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
+        -- IsDeleted flag is set to "1". --
+        1 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
+    FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
+    -- Join input and snapshot table on the defined primary key. --
+    LEFT JOIN {{ tableName.input | quoteIdentifier }} input ON {{ snapshotInputJoinConditionSql }}
+    WHERE
+        -- Deleted records are calculated only from the actual records. --
+        snapshot.{{ columnName.actual | quoteIdentifier }} = 1 AND
+        -- Record is no more present in the input table. --
+        input.{{ inputRandomColumn | quoteIdentifier }} IS NULL;
 
 -- Merge partial results to the new snapshot. --
 -- Incremental loading is used to load table in the storage, --
 -- so old rows with the same primary key are overwritten. --
 CREATE TABLE {{ tableName.newSnapshot | quoteIdentifier }} AS
--- New last state: --
-SELECT
-{{ snapshotPrimaryKeySelect }},
-{{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
-FROM "last_state"
-UNION
--- Deleted records: --
-SELECT
-{{ snapshotPrimaryKeySelect }},
-{{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
-FROM "deleted_records"
-UNION
--- Modified previous state: --
-SELECT
-{{ snapshotPrimaryKeySelect }},
-{{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
-FROM "previous_state";
+    -- Changed records: --
+    SELECT
+        {{ snapshotPrimaryKeySelect }},
+        {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
+    FROM "changed_records"
+        UNION
+    -- Deleted records: --
+    SELECT
+        {{ snapshotPrimaryKeySelect }},
+        {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
+    FROM "deleted_records"
+        UNION
+    -- Updated previous versions of the changed records: --
+    SELECT
+        {{ snapshotPrimaryKeySelect }},
+        {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
+    FROM "updated_records";
+
+

--- a/src/Patterns/templates/Scd4Snowflake.twig
+++ b/src/Patterns/templates/Scd4Snowflake.twig
@@ -55,7 +55,11 @@ CREATE TABLE "previous_state" AS
         -- TLDR: for each PK, we can have max one row in the new snapshot. --
         AND snapshot.{{ columnName.snapshotDate | quoteIdentifier }} != {{ currentDate }};
 
--- Deleted records are missing in input table, but have actual "1" in last snapshot. --
+{% if generateDeletedRecords -%}
+-- Deleted records are generated: --
+-- if "has_deleted_flag" = true OR "keep_del_active" = true --
+-- Detection: Deleted records have actual flag set to "1" --
+-- in the snapshot table, but are missing in input table. --
 CREATE TABLE "deleted_records" AS
     SELECT
         {{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
@@ -70,6 +74,10 @@ CREATE TABLE "deleted_records" AS
     WHERE
         snapshot.{{ columnName.actual | quoteIdentifier }} = 1 AND
         input.{{ inputRandomColumn | quoteIdentifier }} IS NULL;
+{% else -%}
+-- Deleted records are not included in the snapshot, --
+-- "has_deleted_flag" = false AND "keep_del_active" = false --
+{% endif -%}
 
 -- Merge partial results to the new snapshot. --
 -- Incremental loading is used to load table in the storage, --
@@ -81,12 +89,14 @@ CREATE TABLE {{ tableName.newSnapshot | quoteIdentifier }} AS
         {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
     FROM "last_state"
         UNION
+    {% if generateDeletedRecords -%}
     -- Deleted records: --
     SELECT
         {{ snapshotPrimaryKeySelect }},
         {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
     FROM "deleted_records"
         UNION
+    {% endif -%}
     -- Modified previous state: --
     SELECT
         {{ snapshotPrimaryKeySelect }},

--- a/src/Patterns/templates/Scd4Synapse.twig
+++ b/src/Patterns/templates/Scd4Synapse.twig
@@ -23,72 +23,82 @@
 
 -- Last state: Actual snapshot of the all rows  --
 CREATE TABLE "last_state" AS
-SELECT
--- Monitored parameters. --
-{{ macro.selectFromColumns(inputColumns, "input.", true) }},
--- The snapshot date is set to now. --
-{{ currentDate }} AS {{ columnName.snapshotDate | quoteIdentifier }},
--- Actual flag is set to "1". --
-1 AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
-    -- IsDeleted flag is set to "0". --
-    0 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
-FROM {{ tableName.input | quoteIdentifier }} input;
+    SELECT
+        -- Monitored parameters. --
+        {{ macro.selectFromColumns(inputColumns, "input.", true) }},
+        -- The snapshot date is set to now. --
+        {{ currentDate }} AS {{ columnName.snapshotDate | quoteIdentifier }},
+        -- Actual flag is set to "1". --
+        1 AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
+        -- IsDeleted flag is set to "0". --
+        0 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
+    FROM {{ tableName.input | quoteIdentifier }} input;
 
 -- Previous state: Set actual flag to "0" in the previous version of the records. --
 CREATE TABLE "previous_state" AS
-SELECT
--- Monitored parameters. --
-{{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
--- The snapshot date is preserved. --
-{{ columnName.snapshotDate | quoteIdentifier }},
--- Actual flag is set to "0". --
-0  AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
-    -- IsDeleted flag is preserved. --
-    snapshot.{{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
-FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
-WHERE
--- Only the last results are modified. --
-snapshot.{{ columnName.actual | quoteIdentifier }} = 1
--- Exclude records with the current date (and therefore with the same PK). --
--- This can happen if time is not part of the date, eg. "2020-11-04". --
--- Row for this PK is then already included in the "last_state". --
--- TLDR: for each PK, we can have max one row in the new snapshot. --
-AND snapshot.{{ columnName.snapshotDate | quoteIdentifier }} != {{ currentDate }};
+    SELECT
+        -- Monitored parameters. --
+        {{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
+        -- The snapshot date is preserved. --
+        {{ columnName.snapshotDate | quoteIdentifier }},
+        -- Actual flag is set to "0". --
+        0  AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
+        -- IsDeleted flag is preserved. --
+        snapshot.{{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
+    FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
+    WHERE
+        -- Only the last results are modified. --
+        snapshot.{{ columnName.actual | quoteIdentifier }} = 1
+        -- Exclude records with the current date (and therefore with the same PK). --
+        -- This can happen if time is not part of the date, eg. "2020-11-04". --
+        -- Row for this PK is then already included in the "last_state". --
+        -- TLDR: for each PK, we can have max one row in the new snapshot. --
+        AND snapshot.{{ columnName.snapshotDate | quoteIdentifier }} != {{ currentDate }};
 
--- Deleted records are missing in input table, but have actual "1" in last snapshot. --
+{% if generateDeletedRecords -%}
+-- Deleted records are generated: --
+-- if "has_deleted_flag" = true OR "keep_del_active" = true --
+-- Detection: Deleted records have actual flag set to "1" --
+-- in the snapshot table, but are missing in input table. --
 CREATE TABLE "deleted_records" AS
-SELECT
-{{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
--- The snapshot date is set to now. --
-{{ currentDate }} AS {{ columnName.snapshotDate | quoteIdentifier }},
--- The actual flag is set to "{{  deletedActualValue  }}" ("keep_del_active" = {{ config.keepDeleteActive() ? 'true' : 'false' }}). --
-{{ deletedActualValue }} AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
-    -- IsDeleted flag is set to "1". --
-    1 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
-FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
-LEFT JOIN {{ tableName.input | quoteIdentifier }} input ON {{ snapshotInputJoinConditionSql }}
-WHERE
-snapshot.{{ columnName.actual | quoteIdentifier }} = 1 AND
-input.{{ inputRandomColumn | quoteIdentifier }} IS NULL;
+    SELECT
+        {{ macro.selectFromColumns(snapshotInputColumns, "snapshot.") }},
+        -- The snapshot date is set to now. --
+        {{ currentDate }} AS {{ columnName.snapshotDate | quoteIdentifier }},
+        -- The actual flag is set to "{{  deletedActualValue  }}" ("keep_del_active" = {{ config.keepDeleteActive() ? 'true' : 'false' }}). --
+        {{ deletedActualValue }} AS {{ columnName.actual | quoteIdentifier }}{% if config.hasDeletedFlag() %},
+        -- IsDeleted flag is set to "1". --
+        1 AS {{ columnName.isDeleted | quoteIdentifier }}{% endif ~%}
+    FROM {{ tableName.currentSnapshot | quoteIdentifier }} snapshot
+    LEFT JOIN {{ tableName.input | quoteIdentifier }} input ON {{ snapshotInputJoinConditionSql }}
+    WHERE
+        snapshot.{{ columnName.actual | quoteIdentifier }} = 1 AND
+        input.{{ inputRandomColumn | quoteIdentifier }} IS NULL;
+{% else -%}
+-- Deleted records are not included in the snapshot, --
+-- "has_deleted_flag" = false AND "keep_del_active" = false --
+{% endif -%}
 
 -- Merge partial results to the new snapshot. --
 -- Incremental loading is used to load table in the storage, --
 -- so old rows with the same primary key are overwritten. --
 CREATE TABLE {{ tableName.newSnapshot | quoteIdentifier }} AS
--- New last state: --
-SELECT
-{{ snapshotPrimaryKeySelect }},
-{{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
-FROM "last_state"
-UNION
--- Deleted records: --
-SELECT
-{{ snapshotPrimaryKeySelect }},
-{{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
-FROM "deleted_records"
-UNION
--- Modified previous state: --
-SELECT
-{{ snapshotPrimaryKeySelect }},
-{{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
-FROM "previous_state";
+    -- New last state: --
+    SELECT
+        {{ snapshotPrimaryKeySelect }},
+        {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
+    FROM "last_state"
+        UNION
+    {% if generateDeletedRecords -%}
+    -- Deleted records: --
+    SELECT
+        {{ snapshotPrimaryKeySelect }},
+        {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
+    FROM "deleted_records"
+        UNION
+    {% endif -%}
+    -- Modified previous state: --
+    SELECT
+        {{ snapshotPrimaryKeySelect }},
+        {{ macro.selectFromColumns(snapshotAllColumnsExceptPk) }}
+    FROM "previous_state";


### PR DESCRIPTION
- **Ako som kopiroval tie sablony Snfk -> Synapse, tak to nezachovalo odsadenie -> fixnute.**

**A este som raz prechadzal testy a nasiel som jednu drobnost v:**
- `Test 5 - SCD 4 - simple` : https://docs.google.com/document/d/1tIraMMxhXn3Xbduh79vB56mOrnzMicT0gxgxsRr6Xjc/edit
- `Test 8 - SCD 4 - include time in date`: https://docs.google.com/document/d/1mEp74-dFedjLXrmxDK9e-KBVh4rAVct3_9Lq-KQJcPQ/edit
- Teda v testoch, kde is_deleted = false a keep_deleted_active = false.

Problem:
- Zaznam `Robin Outgoing` je vymazany.
- No aj tak sa zapise do history tabulky s actual = 0.
- Je to ok, ak mas is_deleted flag, ze vies ze bol zmazany.
- Alebo mas keep_deleted_active = true, teda ze to presne tak chces (len potom bude aj actual = 1, to je vyriesene)
- No ked mas is_deleted = false a keep_deleted_active = false ...
- ... tak tam ten zaznam vobec nechces ...
- Pretoze pri dalsom snapshote, bude tam kde je actual = 1 -> actual = 0, lebo bude nova verzia.
- A teda potom uz nezistis, .... ci v tom predchadzajucom snapshote bol ten zaznam normalne pritomny alebo zmazany.

#### Test 5 - old
![image](https://user-images.githubusercontent.com/19371734/98210262-8e422680-1f40-11eb-9fbd-882526493673.png)

#### Test 5 - new
![image](https://user-images.githubusercontent.com/19371734/98211861-fdb91580-1f42-11eb-8fc2-8037cb16c998.png)

#### Test 8 - old
![image](https://user-images.githubusercontent.com/19371734/98211970-2e994a80-1f43-11eb-9f34-5bc135f718bb.png)

#### Test 8 - new
![image](https://user-images.githubusercontent.com/19371734/98212531-04945800-1f44-11eb-8c44-a0cf2e390d59.png)
