### PR TITLE
Update: CFT-3354 - Uppercase columns in CSV as well

### DIFF
--- a/src/Patterns/AbstractPattern.php
+++ b/src/Patterns/AbstractPattern.php
@@ -78,6 +78,11 @@ abstract class AbstractPattern extends AbstractExtension implements Pattern
         return array_map(fn(string $column) => mb_strtolower($column), $columns);
     }
 
+    protected function columnsToUpper(array $columns): array
+    {
+        return array_map(fn(string $column) => mb_strtoupper($column), $columns);
+    }
+
     protected function noIndent(string $str): string
     {
         return implode(

--- a/src/Patterns/Scd2Pattern.php
+++ b/src/Patterns/Scd2Pattern.php
@@ -69,7 +69,6 @@ class Scd2Pattern extends AbstractPattern
             'snapshotPrimaryKeyName' => $this->getSnapshotPrimaryKey(),
             'snapshotPrimaryKeyParts' => $this->getSnapshotPrimaryKeyParts(),
             'snapshotInputColumns' => $this->getSnapshotInputColumns(),
-            'snapshotSpecialColumns' => $this->getSnapshotSpecialColumns(),
             'snapshotAllColumnsExceptPk' => $this->getSnapshotAllColumnsExceptPk(),
             'deletedActualValue' => $this->getParameters()->keepDeleteActive()
                 ? $this->getParameters()->getDeletedFlagValue()[1]
@@ -79,12 +78,7 @@ class Scd2Pattern extends AbstractPattern
                 'currentSnapshot' => self::TABLE_CURRENT_SNAPSHOT,
                 'newSnapshot' => self::TABLE_NEW_SNAPSHOT,
             ],
-            'columnName' => [
-                'startDate' => $this->getParameters()->getStartDateName(),
-                'endDate' => $this->getParameters()->getEndDateName(),
-                'actual' => $this->getParameters()->getActualName(),
-                'isDeleted' => $this->getParameters()->getIsDeletedName(),
-            ],
+            'columnName' => $this->getSnapshotSpecialColumnsWithKeys(),
             'endDateValue' => $this->getParameters()->getEndDateValue(),
             'deletedFlagValue' => $this->getParameters()->getDeletedFlagValue(),
             'currentTimestampMinusOne' => $this->getParameters()->getCurrentTimestampMinusOne(),
@@ -114,12 +108,17 @@ class Scd2Pattern extends AbstractPattern
 
     private function getSnapshotSpecialColumns(): array
     {
-        $columns[] = $this->getParameters()->getStartDateName();
-        $columns[] = $this->getParameters()->getEndDateName();
-        $columns[] = $this->getParameters()->getActualName();
+        return array_values($this->getSnapshotSpecialColumnsWithKeys());
+    }
+
+    private function getSnapshotSpecialColumnsWithKeys(): array
+    {
+        $columns['startDate'] = $this->getParameters()->getStartDateName();
+        $columns['endDate'] = $this->getParameters()->getEndDateName();
+        $columns['actual'] = $this->getParameters()->getActualName();
 
         if ($this->getParameters()->hasDeletedFlag()) {
-            $columns[] = $this->getParameters()->getIsDeletedName();
+            $columns['isDeleted'] = $this->getParameters()->getIsDeletedName();
         }
 
         return $this->getParameters()->getUppercaseColumns()

--- a/src/Patterns/Scd2Pattern.php
+++ b/src/Patterns/Scd2Pattern.php
@@ -32,7 +32,9 @@ class Scd2Pattern extends AbstractPattern
 
     public function getSnapshotPrimaryKey(): string
     {
-        return mb_strtolower(self::COLUMN_SNAPSHOT_PK);
+        return $this->getParameters()->getUppercaseColumns()
+            ? mb_strtoupper(self::COLUMN_SNAPSHOT_PK)
+            : self::COLUMN_SNAPSHOT_PK;
     }
 
     public function getSnapshotTableHeader(): array
@@ -105,8 +107,9 @@ class Scd2Pattern extends AbstractPattern
 
     private function getSnapshotInputColumns(): array
     {
-        // All snapshot columns are lower
-        return $this->columnsToLower($this->getInputColumns());
+        return $this->getParameters()->getUppercaseColumns()
+            ? $this->columnsToUpper($this->getInputColumns())
+            : $this->columnsToLower($this->getInputColumns());
     }
 
     private function getSnapshotSpecialColumns(): array
@@ -119,8 +122,9 @@ class Scd2Pattern extends AbstractPattern
             $columns[] = $this->getParameters()->getIsDeletedName();
         }
 
-        // All snapshot columns are lower
-        return $this->columnsToLower($columns);
+        return $this->getParameters()->getUppercaseColumns()
+            ? $this->columnsToUpper($columns)
+            : $this->columnsToLower($columns);
     }
 
     private function getSnapshotAllColumnsExceptPk(): array

--- a/src/Patterns/templates/Scd2Snowflake.twig
+++ b/src/Patterns/templates/Scd2Snowflake.twig
@@ -2,10 +2,10 @@
 {% set inputRandomColumn = attribute(inputPrimaryKey, 0) %}
 {% set snapshotInputJoinConditionSql = macro.generateJoin(inputPrimaryKey, "snapshot", "input", uppercaseColumns) %}
 {% set snapshotPrimaryKeySelect = macro.generateSnapshotPrimaryKey(snapshotPrimaryKeyParts, snapshotPrimaryKeyName, uppercaseColumns) %}
-{% set startDateName = uppercaseColumns ? columnName.startDate|upper|quoteIdentifier : columnName.startDate|quoteIdentifier  %}
-{% set endDateName = uppercaseColumns ? columnName.endDate|upper|quoteIdentifier : columnName.endDate|quoteIdentifier  %}
-{% set actualName = uppercaseColumns ? columnName.actual|upper|quoteIdentifier : columnName.actual|quoteIdentifier  %}
-{% set isDeletedName = uppercaseColumns ? columnName.isDeleted|upper|quoteIdentifier : columnName.isDeleted|quoteIdentifier  %}
+{% set startDateName = columnName.startDate | quoteIdentifier %}
+{% set endDateName = columnName.endDate | quoteIdentifier %}
+{% set actualName = columnName.actual | quoteIdentifier %}
+{% set isDeletedName = hasDeletedFlag ? columnName.isDeleted | quoteIdentifier : ''  %}
 -- SCD2: This method tracks historical data --
 -- by creating new records for new/modified data in the snapshot table. --
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/CFT-3354

Headers v CSV musia byt tiez uppercase + uppercase sa riesi v PHP Pattern class-e namiesto toho aby sa riesil priamo v TWIG-u