### PR TITLE
Fix: CFT-3354 - use config instead of parameters in OutputMapping

### DIFF
--- a/src/Mapping/OutputMapping.php
+++ b/src/Mapping/OutputMapping.php
@@ -47,7 +47,12 @@ class OutputMapping
         $this->newMapping[] = $this->createTable([
             'source' => $this->pattern->getSnapshotOutputTable(),
             'destination' => $snapshotInputMapping->getSource(),
-            'primary_key' => [$this->pattern->getSnapshotPrimaryKey()],
+            'primary_key' => [
+                // Cannot be load from parameters, because they are initialized later 'setParameters'
+                $this->config->getUppercaseColumns()
+                    ? mb_strtoupper(Pattern::COLUMN_SNAPSHOT_PK)
+                    : Pattern::COLUMN_SNAPSHOT_PK,
+            ],
             'incremental' => true,
         ]);
     }

--- a/src/Patterns/Pattern.php
+++ b/src/Patterns/Pattern.php
@@ -8,6 +8,11 @@ use Keboola\TransformationPatternScd\Parameters\Parameters;
 
 interface Pattern
 {
+    public const TABLE_INPUT = 'input_table';
+    public const TABLE_CURRENT_SNAPSHOT = 'current_snapshot';
+    public const TABLE_NEW_SNAPSHOT = 'new_snapshot';
+    public const COLUMN_SNAPSHOT_PK = 'snapshot_pk';
+
     public function getInputTableName(): string;
 
     public function getSnapshotInputTable(): string;

--- a/src/Patterns/Scd2Pattern.php
+++ b/src/Patterns/Scd2Pattern.php
@@ -9,12 +9,6 @@ use Keboola\TransformationPatternScd\Parameters\Parameters;
 
 class Scd2Pattern extends AbstractPattern
 {
-    public const TABLE_INPUT = 'input_table';
-    public const TABLE_CURRENT_SNAPSHOT = 'current_snapshot';
-    public const TABLE_NEW_SNAPSHOT = 'new_snapshot';
-
-    public const COLUMN_SNAPSHOT_PK = 'snapshot_pk';
-
     public function getInputTableName(): string
     {
         return self::TABLE_INPUT;

--- a/src/Patterns/Scd4Pattern.php
+++ b/src/Patterns/Scd4Pattern.php
@@ -9,11 +9,6 @@ use Keboola\TransformationPatternScd\Parameters\Parameters;
 
 class Scd4Pattern extends AbstractPattern
 {
-    public const TABLE_INPUT = 'input_table';
-    public const TABLE_CURRENT_SNAPSHOT = 'current_snapshot';
-    public const TABLE_NEW_SNAPSHOT = 'new_snapshot';
-
-    public const COLUMN_SNAPSHOT_PK = 'snapshot_pk';
     public const COLUMN_SNAPSHOT_DATE = 'snapshot_date';
     public const COLUMN_ACTUAL = 'actual';
     public const COLUMN_IS_DELETED = 'is_deleted';


### PR DESCRIPTION
v outputMapping-u sa pouzivali parameters predtym nez vobec boli inicializovane. Je to troska tricky navrh ale vyriesit sa to da tym ze ten param sa bude tahat z configu

https://app.datadoghq.eu/logs?query=%40exceptionId%3Aexception-2bd395c6b19ec48651f1f8944c094f09&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Ccomponent&event=AwAAAZVw_IdQSO0yswAAABhBWlZ3X0k2TkFBQVd0d2pMR3ZBYl93QU4AAAAkMDE5NTcwZmMtYjcwNi00ZTZiLTgwNzEtZWFkMWVlNjUxYTI5AAAh9A&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=56416&storage=hot&stream_sort=desc&viz=stream&from_ts=1740752571746&to_ts=1741357371746&live=true